### PR TITLE
Enable externally managed VCN infrastructure when creating clusters from tkg-clusterclass-oci.

### DIFF
--- a/pkg/v1/providers/config_default.yaml
+++ b/pkg/v1/providers/config_default.yaml
@@ -700,6 +700,15 @@ OCI_IMAGE_ID:
 OCI_COMPARTMENT_ID:
 OCI_SSH_KEY:
 
+#! Settings to use externally managed network infrastructure
+OCI_EXTERNAL_VCN_ID:
+OCI_EXTERNAL_CONTROL_PLANE_EP_NSG_ID:
+OCI_EXTERNAL_CONTROL_PLANE_NSG_ID:
+OCI_EXTERNAL_WORKER_NSG_ID:
+OCI_EXTERNAL_CONTROL_PLANE_EP_SUBNET_ID:
+OCI_EXTERNAL_CONTROL_PLANE_SUBNET_ID:
+OCI_EXTERNAL_WORKER_SUBNET_ID:
+
 #! ---------------------------------------------------------------------
 #! BoM file processing, internal use only
 #! ---------------------------------------------------------------------

--- a/pkg/v1/providers/infrastructure-oci/v0.4.0/cconly/base.yaml
+++ b/pkg/v1/providers/infrastructure-oci/v0.4.0/cconly/base.yaml
@@ -44,6 +44,48 @@ spec:
         openAPIV3Schema:
           type: string
           default: default
+    - name: externalVCNId
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: ""
+    - name: externalControlPlaneEndpointNSGId
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: ""
+    - name: externalControlPlaneNSGId
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: ""
+    - name: externalWorkerNSGId
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: ""
+    - name: externalControlPlaneEndpointSubnetId
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: ""
+    - name: externalControlPlaneSubnetId
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: ""
+    - name: externalWorkerSubnetId
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: ""
     - name: compartmentId
       required: true
       schema:
@@ -158,6 +200,77 @@ spec:
               path: "/spec/template/spec/compartmentId"
               valueFrom:
                 variable: compartmentId
+    #! JSON Patches for externally managed cluster infrastructure
+    #! these patches are only enabled if a non-empty externalVCNId variable is specified
+    - name: skipNetworkManagement
+      enabledIf: '{{ not (empty .externalVCNId) }}'
+      definitions:
+        - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+          kind: OCIClusterTemplate
+          matchResources:
+            infrastructureCluster: true
+          jsonPatches:
+            - op: add
+              path: "/spec/template/spec/networkSpec/skipNetworkManagement"
+              value: true
+    - name: externalVCNId
+      enabledIf: '{{ not (empty .externalVCNId) }}'
+      definitions:
+        - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+          kind: OCIClusterTemplate
+          matchResources:
+            infrastructureCluster: true
+          jsonPatches:
+            - op: add
+              path: "/spec/template/spec/networkSpec/vcn/id"
+              valueFrom:
+                variable: externalVCNId
+    - name: externalNetworkSecurityGroups
+      enabledIf: '{{ not (empty .externalVCNId) }}'
+      definitions:
+        - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+          kind: OCIClusterTemplate
+          matchResources:
+            infrastructureCluster: true
+          jsonPatches:
+            - op: replace
+              path: "/spec/template/spec/networkSpec/vcn/networkSecurityGroups"
+              valueFrom:
+                template: |
+                  - id: {{ .externalControlPlaneEndpointNSGId }}
+                    role: control-plane-endpoint
+                    name: control-plane-endpoint
+                  - id: {{ .externalWorkerNSGId }}
+                    role: worker
+                    name: worker
+                  - id: {{ .externalControlPlaneNSGId }}
+                    role: control-plane
+                    name: control-plane
+    - name: externalSubnets
+      enabledIf: '{{ not (empty .externalVCNId) }}'
+      definitions:
+        - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+          kind: OCIClusterTemplate
+          matchResources:
+            infrastructureCluster: true
+          jsonPatches:
+            - op: replace
+              path: "/spec/template/spec/networkSpec/vcn/subnets"
+              valueFrom:
+                template: |
+                  - id: {{ .externalControlPlaneEndpointSubnetId }}
+                    role: control-plane-endpoint
+                    name: control-plane-endpoint
+                  - id: {{ .externalWorkerSubnetId }}
+                    role: worker
+                    name: worker
+                  - id: {{ .externalControlPlaneSubnetId }}
+                    role: control-plane
+                    name: control-plane
     - name: sshAuthorizedKeys
       definitions:
         - selector:

--- a/pkg/v1/providers/infrastructure-oci/v0.4.0/yttcc/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-oci/v0.4.0/yttcc/overlay.yaml
@@ -5,7 +5,7 @@
 
 #@ load("@ytt:yaml", "yaml")
 #@ load("@ytt:struct", "struct")
-#@ load("/lib/config_variable_association.star", "config_variable_association", "get_oci_vars")
+#@ load("/lib/config_variable_association.star", "config_variable_association", "get_oci_vars", "oci_var_keys")
 
 #@ load("lib/helpers.star", "get_bom_data_for_tkr_name", "kubeadm_image_repo", "get_default_tkg_bom_data")
 #@ load("lib/validate.star", "validate_configuration")
@@ -92,8 +92,8 @@ spec:
     variables:
       #@ vars = get_oci_vars()
       #@ for configVariable in vars:
-      #@  if vars[configVariable] != None and configVariable in ["imageId", "compartmentId", "sshKey", "nodeMachineShape", "nodeMachineOcpus", "nodePvTransitEncryption", "controlPlaneMachineShape", "controlPlaneMachineOcpus", "controlPlanePvTransitEncryption", "imageRepository", "trust", "auditLogging", "cni", "TKR_DATA"]:
+      #@  if vars[configVariable] != None and configVariable in oci_var_keys:
       - name: #@ configVariable
         value: #@ vars[configVariable]
-    #@ end
-    #@ end
+      #@  end
+      #@ end

--- a/pkg/v1/providers/yttcc/lib/config_variable_association.star
+++ b/pkg/v1/providers/yttcc/lib/config_variable_association.star
@@ -855,6 +855,14 @@ def get_oci_vars():
     simpleMapping["OCI_CONTROL_PLANE_MACHINE_TYPE_OCPUS"] = "controlPlaneMachineOcpus"
     simpleMapping["OCI_CONTROL_PLANE_PV_TRANSIT_ENCRYPTION"] = "controlPlanePvTransitEncryption"
 
+    simpleMapping["OCI_EXTERNAL_VCN_ID"] = "externalVCNId"
+    simpleMapping["OCI_EXTERNAL_CONTROL_PLANE_EP_NSG_ID"] = "externalControlPlaneEndpointNSGId"
+    simpleMapping["OCI_EXTERNAL_CONTROL_PLANE_NSG_ID"] = "externalControlPlaneNSGId"
+    simpleMapping["OCI_EXTERNAL_WORKER_NSG_ID"] = "externalWorkerNSGId"
+    simpleMapping["OCI_EXTERNAL_CONTROL_PLANE_EP_SUBNET_ID"] = "externalControlPlaneEndpointSubnetId"
+    simpleMapping["OCI_EXTERNAL_CONTROL_PLANE_SUBNET_ID"] = "externalControlPlaneSubnetId"
+    simpleMapping["OCI_EXTERNAL_WORKER_SUBNET_ID"] = "externalWorkerSubnetId"
+
     vars = get_cluster_variables()
 
     for key in simpleMapping:
@@ -864,3 +872,11 @@ def get_oci_vars():
     end
     return vars
 end
+
+oci_var_keys = ["imageId", "compartmentId", "sshKey", "nodeMachineShape", "nodeMachineOcpus",
+        "externalVCNId",
+        "externalControlPlaneEndpointNSGId", "externalControlPlaneNSGId", "externalWorkerNSGId",
+        "externalControlPlaneEndpointSubnetId", "externalControlPlaneSubnetId", "externalWorkerSubnetId",
+        "nodePvTransitEncryption", "controlPlaneMachineShape", "controlPlaneMachineOcpus",
+        "controlPlanePvTransitEncryption",
+        "imageRepository", "trust", "auditLogging", "cni", "TKR_DATA"]


### PR DESCRIPTION
### What this PR does / why we need it

This PR allows user to use the externally managed VCN when creating OCI clusters from the tkg-clusterclass-oci.

The tanzu CLI user can optionally provide following configurations

```
export OCI_EXTERNAL_VCN_ID=ocid1.vcn.oc1.us-sanjose-1.amaaxxxxxxxxxxxxcaqklpaa

export OCI_EXTERNAL_CONTROL_PLANE_EP_NSG_ID=ocid1.networksecuritygroup.oc1.us-sanjose-1.aaaaaaaa3xxxxxxxxbvdou45r5cbxq
export OCI_EXTERNAL_CONTROL_PLANE_NSG_ID=ocid1.networksecuritygroup.oc1.us-sanjose-1.aaaaaaaaxxxxxxxxxxxqnl677vskiq
export OCI_EXTERNAL_WORKER_NSG_ID=ocid1.networksecuritygroup.oc1.us-sanjose-1.aaaaaaaahxxxxxebfdq

export OCI_EXTERNAL_CONTROL_PLANE_EP_SUBNET_ID=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaaf6exxxxxxxxayxjzup4a
export OCI_EXTERNAL_CONTROL_PLANE_SUBNET_ID=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaappxxxxxxifls4ymrl5s2eq
export OCI_EXTERNAL_WORKER_SUBNET_ID=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaapprxxxxxxxxxmrl5s2eq
```

The tkg-clusterclass-oci will perform json patches to the `OCICluster` resource once it figured `externalVCNId` is non-empty. As a result, the code snippet [here](https://oracle.github.io/cluster-api-provider-oci/gs/externally-managed-cluster-infrastructure.html#example-spec-for-externally-managed-vcn-infrastructure) will be presented in the OCICluster resource, allowing CAPOCI to skip reconciling the network infrastructure and reuse existing ones.




### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Enable externally managed VCN infrastructure when creating clusters from tkg-clusterclass-oci.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
